### PR TITLE
feat: implement GitHub Actions OIDC authentication

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -16,3 +16,6 @@ VITE_PORT=5173
 DOMAIN_NAME=chrismarasco.io
 SUBDOMAIN=ai-ip
 CREATE_ROUTE53_RECORDS=true
+
+# GitHub configuration for OIDC
+GITHUB_REPOSITORY=cxm6467/ai-interview-prep

--- a/.github/workflows/auth-aws.yml
+++ b/.github/workflows/auth-aws.yml
@@ -15,23 +15,24 @@ on:
         type: string
         default: 'development'
     secrets:
-      AWS_ACCESS_KEY_ID:
+      AWS_ROLE_ARN:
         required: true
-        description: 'AWS Access Key ID'
-      AWS_SECRET_ACCESS_KEY:
-        required: true
-        description: 'AWS Secret Access Key'
+        description: 'AWS IAM Role ARN for OIDC authentication'
+
+permissions:
+  id-token: write
+  contents: read
 
 jobs:
   authenticate:
     runs-on: ubuntu-latest
     
     steps:
-      - name: Configure AWS credentials (Access Keys)
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: GitHubActions-${{ github.run_id }}
           aws-region: ${{ inputs.aws-region }}
           
       - name: Verify AWS authentication

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -10,6 +10,10 @@ env:
   ECR_REPOSITORY: ai-interview-prep-dev
   ENVIRONMENT: dev
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -22,8 +26,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-session-name: GitHubActions-Deploy-${{ github.run_id }}
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Login to Amazon ECR

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -10,6 +10,10 @@ env:
   ECR_REPOSITORY: ai-interview-prep-prod
   ENVIRONMENT: prod
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -22,8 +26,8 @@ jobs:
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v4
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+        role-session-name: GitHubActions-Deploy-${{ github.run_id }}
         aws-region: ${{ env.AWS_REGION }}
 
     - name: Login to Amazon ECR

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -42,6 +42,7 @@ permissions:
   pull-requests: write
   issues: write
   actions: read
+  id-token: write
 
 jobs:
   terraform-plan:
@@ -54,8 +55,8 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: GitHubActions-TerraformPlan-${{ github.run_id }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
           
       - name: Setup Terraform

--- a/iac/github-oidc.tf
+++ b/iac/github-oidc.tf
@@ -1,0 +1,164 @@
+# GitHub OIDC Provider and IAM Role for GitHub Actions
+# This allows GitHub Actions to authenticate to AWS without storing long-lived credentials
+
+# Data source to get current AWS account ID
+data "aws_caller_identity" "current" {}
+
+# GitHub OIDC Identity Provider
+resource "aws_iam_openid_connect_provider" "github" {
+  url = "https://token.actions.githubusercontent.com"
+
+  client_id_list = ["sts.amazonaws.com"]
+
+  thumbprint_list = [
+    "6938fd4d98bab03faadb97b34396831e3780aea1",
+    "1c58a3a8518e8759bf075b76b750d4f2df264fcd"
+  ]
+
+  tags = {
+    Name        = "github-actions-oidc"
+    Environment = var.environment
+    Application = var.app_name
+  }
+}
+
+# IAM Role for GitHub Actions
+resource "aws_iam_role" "github_actions" {
+  name = "${var.app_name}-${var.environment}-github-actions"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = aws_iam_openid_connect_provider.github.arn
+        }
+        Action = "sts:AssumeRole"
+        Condition = {
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"
+          }
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" = "repo:${var.github_repository}:*"
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.app_name}-${var.environment}-github-actions"
+    Environment = var.environment
+    Application = var.app_name
+  }
+}
+
+# Policy for GitHub Actions - ECR and Lambda deployment permissions
+resource "aws_iam_policy" "github_actions_policy" {
+  name        = "${var.app_name}-${var.environment}-github-actions-policy"
+  description = "Policy for GitHub Actions to deploy infrastructure and applications"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      # ECR permissions
+      {
+        Effect = "Allow"
+        Action = [
+          "ecr:GetAuthorizationToken",
+          "ecr:BatchCheckLayerAvailability",
+          "ecr:GetDownloadUrlForLayer",
+          "ecr:BatchGetImage",
+          "ecr:BatchImportImage",
+          "ecr:CompleteLayerUpload",
+          "ecr:UploadLayerPart",
+          "ecr:InitiateLayerUpload",
+          "ecr:PutImage"
+        ]
+        Resource = "*"
+      },
+      # Lambda permissions
+      {
+        Effect = "Allow"
+        Action = [
+          "lambda:UpdateFunctionCode",
+          "lambda:UpdateFunctionConfiguration",
+          "lambda:GetFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:PublishVersion"
+        ]
+        Resource = "arn:aws:lambda:${var.aws_region}:${data.aws_caller_identity.current.account_id}:function:${var.app_name}-${var.environment}"
+      },
+      # CloudWatch Logs
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogGroups",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:/aws/lambda/${var.app_name}-${var.environment}*"
+      },
+      # S3 for frontend deployment
+      {
+        Effect = "Allow"
+        Action = [
+          "s3:GetObject",
+          "s3:PutObject",
+          "s3:DeleteObject",
+          "s3:ListBucket"
+        ]
+        Resource = [
+          "arn:aws:s3:::${var.app_name}-${var.environment}-frontend",
+          "arn:aws:s3:::${var.app_name}-${var.environment}-frontend/*"
+        ]
+      },
+      # CloudFront invalidation
+      {
+        Effect = "Allow"
+        Action = [
+          "cloudfront:CreateInvalidation",
+          "cloudfront:GetInvalidation",
+          "cloudfront:ListInvalidations"
+        ]
+        Resource = "*"
+      },
+      # Terraform state and general AWS access
+      {
+        Effect = "Allow"
+        Action = [
+          "sts:GetCallerIdentity",
+          "iam:GetRole",
+          "iam:PassRole"
+        ]
+        Resource = "*"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "${var.app_name}-${var.environment}-github-actions-policy"
+    Environment = var.environment
+    Application = var.app_name
+  }
+}
+
+# Attach policy to role
+resource "aws_iam_role_policy_attachment" "github_actions_policy_attachment" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = aws_iam_policy.github_actions_policy.arn
+}
+
+# Output the role ARN for use in GitHub Actions
+output "github_actions_role_arn" {
+  description = "ARN of the GitHub Actions OIDC role"
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "github_oidc_provider_arn" {
+  description = "ARN of the GitHub OIDC provider"
+  value       = aws_iam_openid_connect_provider.github.arn
+}

--- a/iac/github-oidc.tf
+++ b/iac/github-oidc.tf
@@ -126,6 +126,29 @@ resource "aws_iam_policy" "github_actions_policy" {
         ]
         Resource = "*"
       },
+      # Route 53 permissions for DNS and SSL certificates
+      {
+        Effect = "Allow"
+        Action = [
+          "route53:ListHostedZones",
+          "route53:GetHostedZone",
+          "route53:ChangeResourceRecordSets",
+          "route53:GetChange",
+          "route53:ListResourceRecordSets"
+        ]
+        Resource = "*"
+      },
+      # ACM (SSL Certificate) permissions
+      {
+        Effect = "Allow"
+        Action = [
+          "acm:ListCertificates",
+          "acm:DescribeCertificate",
+          "acm:RequestCertificate",
+          "acm:AddTagsToCertificate"
+        ]
+        Resource = "*"
+      },
       # Terraform state and general AWS access
       {
         Effect = "Allow"

--- a/iac/github-oidc.tf
+++ b/iac/github-oidc.tf
@@ -134,7 +134,8 @@ resource "aws_iam_policy" "github_actions_policy" {
           "route53:GetHostedZone",
           "route53:ChangeResourceRecordSets",
           "route53:GetChange",
-          "route53:ListResourceRecordSets"
+          "route53:ListResourceRecordSets",
+          "route53:ListTagsForResource"
         ]
         Resource = "*"
       },

--- a/iac/github-oidc.tf
+++ b/iac/github-oidc.tf
@@ -34,7 +34,7 @@ resource "aws_iam_role" "github_actions" {
         Principal = {
           Federated = aws_iam_openid_connect_provider.github.arn
         }
-        Action = "sts:AssumeRole"
+        Action = "sts:AssumeRoleWithWebIdentity"
         Condition = {
           StringEquals = {
             "token.actions.githubusercontent.com:aud" = "sts.amazonaws.com"

--- a/iac/terraform.tfvars.example
+++ b/iac/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# Terraform Variables for AI Interview Prep
+# Copy this file to terraform.tfvars and fill in the values
+
+# Required: OpenAI API Key
+openai_api_key = "your-openai-api-key-here"
+
+# Optional: Override defaults if needed
+# aws_region = "us-east-1"
+# environment = "development" 
+# app_name = "ai-interview-prep"
+# domain_name = "chrismarasco.io"
+# subdomain = "ai-ip"
+# github_repository = "cxm6467/ai-interview-prep"

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -57,3 +57,9 @@ variable "create_route53_records" {
   type        = bool
   default     = true
 }
+
+variable "github_repository" {
+  description = "GitHub repository in the format owner/repo-name (e.g., cxm6467/ai-interview-prep)"
+  type        = string
+  default     = "cxm6467/ai-interview-prep"
+}


### PR DESCRIPTION
- Created AWS OIDC provider and IAM role for GitHub Actions
- Added github-oidc.tf with complete OIDC infrastructure
- Updated all workflows to use OIDC instead of access keys:
  - auth-aws.yml: Updated to use role-to-assume
  - deploy-dev.yml: Added OIDC authentication
  - deploy-prod.yml: Added OIDC authentication
  - terraform-plan.yml: Added OIDC authentication
- Added required permissions (id-token: write) to workflows
- Created terraform.tfvars.example for configuration

OIDC Role ARN: arn:aws:iam::276362266002:role/ai-interview-prep-development-github-actions

Next step: Add AWS_ROLE_ARN secret to GitHub repo settings.