### PR TITLE
fix: update deploy-backend.yml to use OIDC authentication properly

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -40,6 +40,10 @@ on:
 env:
   TF_VERSION: '1.6.0'
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   terraform-plan:
     runs-on: ubuntu-latest
@@ -51,20 +55,11 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Configure AWS credentials (OIDC)
-        if: ${{ vars.AWS_ROLE_ARN != '' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: GitHubActions-Deploy-${{ github.run_id }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
-          
-      - name: Configure AWS credentials (Access Keys)
-        if: ${{ vars.AWS_ROLE_ARN == '' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+          aws-region: us-east-1
           
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -150,20 +145,11 @@ jobs:
         uses: actions/checkout@v4
         
       - name: Configure AWS credentials (OIDC)
-        if: ${{ vars.AWS_ROLE_ARN != '' }}
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           role-session-name: GitHubActions-Deploy-${{ github.run_id }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
-          
-      - name: Configure AWS credentials (Access Keys)
-        if: ${{ vars.AWS_ROLE_ARN == '' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+          aws-region: us-east-1
           
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3


### PR DESCRIPTION
- Added missing id-token: write permission for OIDC authentication
- Changed from vars.AWS_ROLE_ARN to secrets.AWS_ROLE_ARN (matches other workflows)
- Removed fallback to access keys since we're using OIDC consistently
- Fixed aws-region to use hardcoded us-east-1 instead of variables

This resolves the "Credentials could not be loaded" error by ensuring the workflow can access the AWS_ROLE_ARN secret properly.