### PR TITLE
fix: update cache-dependency-path to use root package-lock.json

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -73,7 +73,7 @@ jobs:
       with:
         node-version: '18'
         cache: 'npm'
-        cache-dependency-path: apps/frontend/package-lock.json
+        cache-dependency-path: package-lock.json
 
     - name: Build Frontend
       run: |


### PR DESCRIPTION
- Changed from apps/frontend/package-lock.json to package-lock.json
- Resolves 'unable to cache dependencies' error in GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)