### PR TITLE
feat: create bootstrap configuration for GitHub Actions OIDC setup

### DIFF
--- a/iac/bootstrap/.terraform.lock.hcl
+++ b/iac/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:edXOJWE4ORX8Fm+dpVpICzMZJat4AX0VRCAy/xkcOc0=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/iac/bootstrap/main.tf
+++ b/iac/bootstrap/main.tf
@@ -1,5 +1,27 @@
-# GitHub OIDC Provider and IAM Role for GitHub Actions
-# This allows GitHub Actions to authenticate to AWS without storing long-lived credentials
+# Bootstrap Terraform configuration for GitHub OIDC setup
+# This needs to be applied first before the main infrastructure
+
+terraform {
+  required_version = ">= 1.5.0"
+  
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  default_tags {
+    tags = {
+      Project   = var.app_name
+      ManagedBy = "terraform-bootstrap"
+    }
+  }
+}
 
 # Data source to get current AWS account ID
 data "aws_caller_identity" "current" {}
@@ -54,7 +76,7 @@ resource "aws_iam_role" "github_actions" {
   }
 }
 
-# Policy for GitHub Actions - ECR and Lambda deployment permissions
+# Policy for GitHub Actions - comprehensive permissions for Terraform deployment
 resource "aws_iam_policy" "github_actions_policy" {
   name        = "${var.app_name}-${var.environment}-github-actions-policy"
   description = "Policy for GitHub Actions to deploy infrastructure and applications"
@@ -260,15 +282,4 @@ resource "aws_iam_policy" "github_actions_policy" {
 resource "aws_iam_role_policy_attachment" "github_actions_policy_attachment" {
   role       = aws_iam_role.github_actions.name
   policy_arn = aws_iam_policy.github_actions_policy.arn
-}
-
-# Output the role ARN for use in GitHub Actions
-output "github_actions_role_arn" {
-  description = "ARN of the GitHub Actions OIDC role"
-  value       = aws_iam_role.github_actions.arn
-}
-
-output "github_oidc_provider_arn" {
-  description = "ARN of the GitHub OIDC provider"
-  value       = aws_iam_openid_connect_provider.github.arn
 }

--- a/iac/bootstrap/outputs.tf
+++ b/iac/bootstrap/outputs.tf
@@ -1,0 +1,10 @@
+# Output the role ARN for use in GitHub Actions
+output "github_actions_role_arn" {
+  description = "ARN of the GitHub Actions OIDC role"
+  value       = aws_iam_role.github_actions.arn
+}
+
+output "github_oidc_provider_arn" {
+  description = "ARN of the GitHub OIDC provider"
+  value       = aws_iam_openid_connect_provider.github.arn
+}

--- a/iac/bootstrap/variables.tf
+++ b/iac/bootstrap/variables.tf
@@ -1,0 +1,23 @@
+variable "aws_region" {
+  description = "The AWS region to deploy the resources in"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "environment" {
+  description = "The deployment environment (development, staging, production)"
+  type        = string
+  default     = "development"
+}
+
+variable "app_name" {
+  description = "Application name used for resource naming"
+  type        = string
+  default     = "ai-interview-prep"
+}
+
+variable "github_repository" {
+  description = "GitHub repository in the format owner/repo-name (e.g., cxm6467/ai-interview-prep)"
+  type        = string
+  default     = "cxm6467/ai-interview-prep"
+}


### PR DESCRIPTION
- Create separate bootstrap Terraform config for OIDC deployment
- Import existing OIDC provider, role, and policy into bootstrap state
- Update IAM policy with comprehensive permissions for Terraform deployment
- Remove duplicate github-oidc.tf from root iac directory
- GitHub Actions role now has all required permissions for infrastructure deployment