### PR TITLE
Fix EntityAlreadyExists errors and add missing ECR permissions

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -103,11 +103,20 @@ jobs:
         terraform init
 
 
-    - name: Sync Terraform State
+    - name: Import Existing Resources
       run: |
         cd iac/environments/dev
         terraform force-unlock -force 5641d5f9-80d8-2505-48b8-9927011fd16b || echo "No stuck locks"
-        echo "🔄 Syncing state with AWS resources..."
+        
+        # Fast import of only conflicting resources
+        terraform import -var="openai_api_key=${{ secrets.OPENAI_API_KEY }}" module.lambda.aws_iam_policy.lambda_policy arn:aws:iam::276362266002:policy/ai-interview-prep-dev-policy || echo "Already imported"
+        terraform import -var="openai_api_key=${{ secrets.OPENAI_API_KEY }}" module.lambda.aws_iam_policy.lambda_metrics_policy[0] arn:aws:iam::276362266002:policy/ai-interview-prep-dev-metrics-policy || echo "Already imported"  
+        terraform import -var="openai_api_key=${{ secrets.OPENAI_API_KEY }}" module.lambda.aws_cloudwatch_log_group.lambda_logs /aws/lambda/ai-interview-prep-dev || echo "Already imported"
+        terraform import -var="openai_api_key=${{ secrets.OPENAI_API_KEY }}" module.security.aws_iam_role.api_gateway_cloudwatch_role api-gateway-cloudwatch-dev-ai-ip-chrismarasco-io || echo "Already imported"
+        terraform import -var="openai_api_key=${{ secrets.OPENAI_API_KEY }}" module.security.aws_iam_policy.api_gateway_cloudwatch_policy arn:aws:iam::276362266002:policy/api-gateway-cloudwatch-dev-ai-ip-chrismarasco-io || echo "Already imported"
+        terraform import -var="openai_api_key=${{ secrets.OPENAI_API_KEY }}" module.security.aws_iam_role.route53_cert_validation_role route53-cert-validation-dev-ai-ip-chrismarasco-io || echo "Already imported"
+        terraform import -var="openai_api_key=${{ secrets.OPENAI_API_KEY }}" module.security.aws_iam_policy.route53_cert_validation_policy arn:aws:iam::276362266002:policy/route53-cert-validation-dev-ai-ip-chrismarasco-io || echo "Already imported"
+        echo "🔄 Import completed"
 
     - name: Terraform Plan
       run: |

--- a/iac/bootstrap/main.tf
+++ b/iac/bootstrap/main.tf
@@ -106,7 +106,10 @@ resource "aws_iam_policy" "github_actions_policy" {
           "ecr:GetRepositoryPolicy",
           "ecr:ListTagsForResource",
           "ecr:TagResource",
-          "ecr:UntagResource"
+          "ecr:UntagResource",
+          "ecr:PutLifecyclePolicy",
+          "ecr:GetLifecyclePolicy",
+          "ecr:DeleteLifecyclePolicy"
         ]
         Resource = "*"
       },


### PR DESCRIPTION
- Add ECR lifecycle policy permissions to bootstrap IAM policy
- Restore targeted import step for only conflicting resources
- Fast imports with proper error handling using || echo
- This should resolve both the EntityAlreadyExists and AccessDenied errors
