### PR TITLE
Fix S3 bucket permissions and add import blocks for existing resources

### DIFF
--- a/iac/bootstrap/main.tf
+++ b/iac/bootstrap/main.tf
@@ -182,8 +182,8 @@ resource "aws_iam_policy" "github_actions_policy" {
           "s3:GetBucketCORS"
         ]
         Resource = [
-          "arn:aws:s3:::${var.app_name}-${var.environment}-frontend",
-          "arn:aws:s3:::${var.app_name}-${var.environment}-frontend/*"
+          "arn:aws:s3:::${var.app_name}-*-frontend",
+          "arn:aws:s3:::${var.app_name}-*-frontend/*"
         ]
       },
       # CloudFront permissions

--- a/iac/environments/dev/main.tf
+++ b/iac/environments/dev/main.tf
@@ -109,3 +109,14 @@ module "frontend" {
 
   depends_on = [module.security]
 }
+
+# Import blocks for existing resources
+import {
+  to = module.lambda.aws_cloudwatch_log_group.lambda_logs
+  id = "/aws/lambda/ai-interview-prep-dev"
+}
+
+import {
+  to = module.frontend.aws_s3_bucket.frontend
+  id = "ai-interview-prep-dev-frontend"
+}


### PR DESCRIPTION
- Fix S3 resource ARN pattern to support all environments (ai-interview-prep-*-frontend)
- Add Terraform import blocks for existing CloudWatch Log Group and S3 bucket
- This follows modern Terraform import practices using configuration-based imports
- Should resolve s3:CreateBucket AccessDenied and ResourceAlreadyExists errors

Per AWS IAM documentation, using wildcards allows permissions across environments Per Terraform documentation, import blocks are the modern way to handle existing resources