### PR TITLE
fix: add S3 object lock and Lambda versions permissions

### DIFF
--- a/iac/bootstrap/main.tf
+++ b/iac/bootstrap/main.tf
@@ -128,7 +128,8 @@ resource "aws_iam_policy" "github_actions_policy" {
           "lambda:RemovePermission",
           "lambda:ListTags",
           "lambda:TagResource",
-          "lambda:UntagResource"
+          "lambda:UntagResource",
+          "lambda:ListVersionsByFunction"
         ]
         Resource = "*"
       },
@@ -193,7 +194,9 @@ resource "aws_iam_policy" "github_actions_policy" {
           "s3:GetReplicationConfiguration",
           "s3:PutReplicationConfiguration",
           "s3:GetEncryptionConfiguration",
-          "s3:PutEncryptionConfiguration"
+          "s3:PutEncryptionConfiguration",
+          "s3:GetBucketObjectLockConfiguration",
+          "s3:PutBucketObjectLockConfiguration"
         ]
         Resource = [
           "arn:aws:s3:::${var.app_name}-*-frontend",


### PR DESCRIPTION
- Add s3:GetBucketObjectLockConfiguration and s3:PutBucketObjectLockConfiguration permissions
- Add lambda:ListVersionsByFunction permission
- Resolves remaining S3 bucket and Lambda function access denied errors during deployment

🤖 Generated with [Claude Code](https://claude.ai/code)