### PR TITLE
fix: add Lambda function URL configuration permissions

### DIFF
--- a/iac/bootstrap/main.tf
+++ b/iac/bootstrap/main.tf
@@ -129,7 +129,11 @@ resource "aws_iam_policy" "github_actions_policy" {
           "lambda:ListTags",
           "lambda:TagResource",
           "lambda:UntagResource",
-          "lambda:ListVersionsByFunction"
+          "lambda:ListVersionsByFunction",
+          "lambda:GetFunctionUrlConfig",
+          "lambda:CreateFunctionUrlConfig",
+          "lambda:UpdateFunctionUrlConfig",
+          "lambda:DeleteFunctionUrlConfig"
         ]
         Resource = "*"
       },


### PR DESCRIPTION
- Add lambda:GetFunctionUrlConfig, CreateFunctionUrlConfig, UpdateFunctionUrlConfig, DeleteFunctionUrlConfig permissions
- Resolves Lambda function URL access denied errors during deployment

🤖 Generated with [Claude Code](https://claude.ai/code)