### PR TITLE
fix: add Lambda GetPolicy permission

### DIFF
--- a/iac/bootstrap/main.tf
+++ b/iac/bootstrap/main.tf
@@ -133,7 +133,8 @@ resource "aws_iam_policy" "github_actions_policy" {
           "lambda:GetFunctionUrlConfig",
           "lambda:CreateFunctionUrlConfig",
           "lambda:UpdateFunctionUrlConfig",
-          "lambda:DeleteFunctionUrlConfig"
+          "lambda:DeleteFunctionUrlConfig",
+          "lambda:GetPolicy"
         ]
         Resource = "*"
       },


### PR DESCRIPTION
- Add lambda:GetPolicy permission for API Gateway Lambda permissions
- Resolves "User is not authorized to perform: lambda:GetPolicy" error
- Allows reading Lambda permission policies during deployment

🤖 Generated with [Claude Code](https://claude.ai/code)