### PR TITLE
fix: simplify Docker build to avoid manifest issues with Lambda

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -44,14 +44,13 @@ jobs:
     - name: Build and push Docker image
       id: build-image
       run: |
-        # Build Docker image for lambda
+        # Build Docker image for lambda with single platform
         docker buildx build \
           --platform linux/amd64 \
           --file iac/Dockerfile \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:latest \
-          --push \
-          --output type=image,push=true .
+          --push .
         
         # Get the single platform image digest using AWS CLI
         IMAGE_DIGEST=$(aws ecr describe-images \


### PR DESCRIPTION
- Remove --output type=image,push=true parameter from docker buildx build
- Keep single --platform linux/amd64 and --push for cleaner manifest
- Resolves "image manifest, config or layer media type is not supported" error
- Ensures Lambda-compatible single-platform image format

🤖 Generated with [Claude Code](https://claude.ai/code)