### PR TITLE
fix: replace Docker Buildx with standard docker build for Lambda comp…

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -37,22 +37,20 @@ jobs:
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@v2
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-
     - name: Build and push Docker image
       id: build-image
       run: |
-        # Build Docker image for lambda with single platform
-        docker buildx build \
-          --platform linux/amd64 \
+        # Build Docker image for lambda using standard docker build (no buildx)
+        docker build \
           --file iac/Dockerfile \
           --tag $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA \
-          --tag $ECR_REGISTRY/$ECR_REPOSITORY:latest \
-          --push .
+          --tag $ECR_REGISTRY/$ECR_REPOSITORY:latest .
         
-        # Get the single platform image digest using AWS CLI
+        # Push both tags
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+        docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+        
+        # Get the image digest using AWS CLI
         IMAGE_DIGEST=$(aws ecr describe-images \
           --repository-name $ECR_REPOSITORY \
           --image-ids imageTag=$GITHUB_SHA \


### PR DESCRIPTION
…atibility

- Remove Docker Buildx setup and use standard docker build command
- Separate build and push operations for cleaner image manifest
- Standard docker build creates Lambda-compatible image format by default
- Resolves persistent "image manifest, config or layer media type is not supported" error

🤖 Generated with [Claude Code](https://claude.ai/code)