### PR TITLE
fix: add log delivery permissions and resource imports

### DIFF
--- a/iac/bootstrap/main.tf
+++ b/iac/bootstrap/main.tf
@@ -158,7 +158,11 @@ resource "aws_iam_policy" "github_actions_policy" {
           "logs:UntagLogGroup",
           "logs:ListTagsForResource",
           "logs:TagResource",
-          "logs:UntagResource"
+          "logs:UntagResource",
+          "logs:CreateLogDelivery",
+          "logs:DeleteLogDelivery",
+          "logs:DescribeLogDeliveries",
+          "logs:GetLogDelivery"
         ]
         Resource = "*"
       },
@@ -298,6 +302,16 @@ resource "aws_iam_policy" "github_actions_policy" {
         Effect = "Allow"
         Action = [
           "apigateway:*"
+        ]
+        Resource = "*"
+      },
+      # Additional IAM permissions for resource management
+      {
+        Effect = "Allow"
+        Action = [
+          "iam:CreateServiceLinkedRole",
+          "iam:GetServiceLinkedRoleDeletionStatus",
+          "iam:DeleteServiceLinkedRole"
         ]
         Resource = "*"
       },

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -9,6 +9,27 @@ locals {
   full_domain = var.environment == "development" ? "dev.${var.subdomain}.${var.domain_name}" : "${var.subdomain}.${var.domain_name}"
 }
 
+# Import existing resources to avoid EntityAlreadyExists errors
+import {
+  to = aws_ecr_repository.lambda_repo
+  id = "ai-interview-prep-development"
+}
+
+import {
+  to = aws_iam_role.lambda_exec_role
+  id = "ai-interview-prep-development-lambda-role"
+}
+
+import {
+  to = aws_iam_policy.lambda_policy
+  id = "arn:aws:iam::276362266002:policy/ai-interview-prep-development-lambda-policy"
+}
+
+import {
+  to = aws_cloudwatch_log_group.lambda_logs
+  id = "/aws/lambda/ai-interview-prep-development"
+}
+
 # ECR Repository to store the Docker Image
 resource "aws_ecr_repository" "lambda_repo" {
   name = "${var.app_name}-${var.environment}"


### PR DESCRIPTION
- Add logs:CreateLogDelivery, DeleteLogDelivery, DescribeLogDeliveries, GetLogDelivery permissions
- Add iam:CreateServiceLinkedRole permissions for API Gateway service roles
- Add import blocks for existing resources to avoid EntityAlreadyExists errors
- Import ECR repo, IAM role/policy, and CloudWatch log group for ai-interview-prep-development
- Resolves "Insufficient permissions to enable logging" and resource creation conflicts

🤖 Generated with [Claude Code](https://claude.ai/code)