### PR TITLE
fix: resolve Lambda manifest and resource conflict issues

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -47,6 +47,16 @@ import {
   id = "26d8r5k3sg" # Most recent ai-interview-prep-development-api
 }
 
+import {
+  to = aws_apigatewayv2_stage.api_stage
+  id = "26d8r5k3sg/$default"
+}
+
+import {
+  to = aws_route53_record.api_record[0]
+  id = "Z09619741MD1JY4BVC74L_dev.ai-ip.chrismarasco.io_A"
+}
+
 # ECR Repository to store the Docker Image
 resource "aws_ecr_repository" "lambda_repo" {
   name = "${var.app_name}-${var.environment}"
@@ -110,7 +120,7 @@ resource "aws_cloudwatch_log_group" "lambda_logs" {
 resource "aws_lambda_function" "ai_handler" {
   function_name = "${var.app_name}-${var.environment}"
   package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.lambda_repo.repository_url}:latest"
+  image_uri     = var.lambda_image_uri != "" ? var.lambda_image_uri : "${aws_ecr_repository.lambda_repo.repository_url}:latest"
   role          = aws_iam_role.lambda_exec_role.arn
   timeout       = var.lambda_timeout
   memory_size   = var.lambda_memory

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -22,6 +22,12 @@ variable "openai_api_key" {
   sensitive   = true
 }
 
+variable "lambda_image_uri" {
+  description = "The Lambda function container image URI (optional, defaults to latest)"
+  type        = string
+  default     = ""
+}
+
 variable "lambda_timeout" {
   description = "Lambda function timeout in seconds"
   type        = number


### PR DESCRIPTION
- Add import blocks for aws_apigatewayv2_stage and aws_route53_record
- Add lambda_image_uri variable for flexible Lambda image specification
- Rebuild Docker image with standard docker build for Lambda compatibility
- Resolves InvalidParameterValueException for image manifest format
- Resolves ConflictException for existing API Gateway stage and Route53 record

🤖 Generated with [Claude Code](https://claude.ai/code)